### PR TITLE
percolator: verify snapshot isolation property.

### DIFF
--- a/Percolator/Percolator.cfg
+++ b/Percolator/Percolator.cfg
@@ -1,5 +1,5 @@
 CONSTANT
-  KEY <- 1..5
+  KEY <- 1..3
   CLIENT <- {"C1", "C2", "C3"}
 
 SPECIFICATION
@@ -11,3 +11,4 @@ INVARIANT
   LockConsistency
   CommittedConsistency
   AbortedConsistency
+  SnapshotIsolation

--- a/Percolator/Percolator.tla
+++ b/Percolator/Percolator.tla
@@ -209,8 +209,10 @@ Start(c) ==
   /\ client_ts' = [client_ts EXCEPT ![c].start_ts = next_ts']
   /\ UNCHANGED <<key_vars, client_key>>
 
-\* Advances to prewrite phase, or tries to clean up one stale lock if we are
-\* going to read the corresponding key.
+\* Does either one thing from these following threes.
+\*  1. Advances to prewrite phase,
+\*  2. Tries to clean up one stale lock,
+\*  3. Reads one key if no stale lock.
 Get(c) ==
   /\ client_state[c] = "working"
   /\ \/ /\ client_state' = [client_state EXCEPT ![c] = "prewriting"]

--- a/Percolator/Percolator.tla
+++ b/Percolator/Percolator.tla
@@ -196,8 +196,8 @@ commitPrimary(c) ==
     primary == client_key[c].primary
   IN
     /\ hasLockEQ(primary, start_ts)
-    /\ key_lock' = [key_lock EXCEPT ![primary] = @ \ {[ts |-> start_ts, primary |-> primary]}]
     /\ key_write' = [key_write EXCEPT ![primary] = Append(@, client_ts[c])]
+    /\ key_lock' = [key_lock EXCEPT ![primary] = @ \ {[ts |-> start_ts, primary |-> primary]}]
     /\ checkSnapshotIsolation(primary, commit_ts)
     /\ UNCHANGED <<key_data, key_last_read_ts>>
 


### PR DESCRIPTION
This PR verifies the snapshot isolation property of Percolator.

The original idea is to use a new sequence variable like `key_rwlog` to log all reads and writes when they happen. For read, log its `start_ts`, for write, log its `commit_ts`. So the snapshot isolation property should be equivalent to, forall `R` that happens before `W`, should have `R_{start_ts} < W_{commit_ts}`.

But this can explode TLC since it significantly increase the state space to explore. An improved design is to only record the last read timestamp, when writing a new version, compare its `commit_ts` with the last read ts to see if the snapshot isolation property is preserved.

This approach can make TLC finish model checking with 3 keys and 3 clients with ~30 seconds on my laptop.