### PR TITLE
RaftMerge: rollback and TLC models.

### DIFF
--- a/RaftMerge/RaftMerge.tla
+++ b/RaftMerge/RaftMerge.tla
@@ -341,8 +341,8 @@ ApplyMergeLog(i) ==
        \/ ApplyMergeLogStep2(i)
 
 \* Apply LogRollback.
-\* As we don't skip all logs after PreMerge log, rollback just marks the state
-\* of region as normal.
+\* As we skip all logs after PreMerge log, rollback just marks the state of
+\* region as normal.
 ApplyRollbackLog(i) ==
   LET
     next_index == raft[i][RegionB].apply_index + 1

--- a/RaftMerge/RaftMerge.toolbox/RaftMerge___Test1.launch
+++ b/RaftMerge/RaftMerge.toolbox/RaftMerge___Test1.launch
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.lamport.tla.toolbox.tool.tlc.modelCheck">
+<stringAttribute key="TLCCmdLineParameters" value="-workers 2"/>
+<stringAttribute key="configurationName" value="Test1"/>
+<booleanAttribute key="deferLiveness" value="false"/>
+<intAttribute key="dfidDepth" value="100"/>
+<booleanAttribute key="dfidMode" value="false"/>
+<intAttribute key="distributedFPSetCount" value="0"/>
+<stringAttribute key="distributedNetworkInterface" value="172.17.0.1"/>
+<intAttribute key="distributedNodesCount" value="1"/>
+<stringAttribute key="distributedTLC" value="off"/>
+<stringAttribute key="distributedTLCVMArgs" value=""/>
+<intAttribute key="fpBits" value="1"/>
+<intAttribute key="fpIndex" value="1"/>
+<intAttribute key="maxHeapSize" value="25"/>
+<intAttribute key="maxSetSize" value="1000000"/>
+<booleanAttribute key="mcMode" value="true"/>
+<stringAttribute key="modelBehaviorInit" value=""/>
+<stringAttribute key="modelBehaviorNext" value=""/>
+<stringAttribute key="modelBehaviorSpec" value="Spec"/>
+<intAttribute key="modelBehaviorSpecType" value="1"/>
+<stringAttribute key="modelBehaviorVars" value="client_requests_index, messages, raft, region"/>
+<stringAttribute key="modelComments" value=""/>
+<booleanAttribute key="modelCorrectnessCheckDeadlock" value="true"/>
+<listAttribute key="modelCorrectnessInvariants">
+<listEntry value="1TypeInvariant"/>
+<listEntry value="1OneLeaderInvariant"/>
+<listEntry value="1AppendEntriesMessageInvariant"/>
+<listEntry value="1LogInvariant"/>
+<listEntry value="1ApplyIndexInvariant"/>
+<listEntry value="1RegionApplyInvariant"/>
+<listEntry value="1MergeLogInvariant"/>
+</listAttribute>
+<listAttribute key="modelCorrectnessProperties"/>
+<stringAttribute key="modelExpressionEval" value=""/>
+<stringAttribute key="modelParameterActionConstraint" value=""/>
+<listAttribute key="modelParameterConstants">
+<listEntry value="LeaderA;;1;0;0"/>
+<listEntry value="LeaderB;;2;0;0"/>
+<listEntry value="Store;;{1,2};0;0"/>
+<listEntry value="RegionA;;RegionA;1;0"/>
+<listEntry value="RegionB;;RegionB;1;0"/>
+<listEntry value="AppendEntriesReply;;AppendEntriesReply;1;0"/>
+<listEntry value="Region;;{RegionA, RegionB};0;0"/>
+<listEntry value="AppendEntriesRequest;;AppendEntriesRequest;1;0"/>
+<listEntry value="MaxClientRequests;;2;0;0"/>
+<listEntry value="QuorumSize;;1;0;0"/>
+<listEntry value="LogNormal;;LogNormal;1;0"/>
+<listEntry value="RegionNormal;;RegionNormal;1;0"/>
+<listEntry value="LogPreMerge;;LogPreMerge;1;0"/>
+<listEntry value="LogMerge;;LogMerge;1;0"/>
+<listEntry value="RegionMerging;;RegionMerging;1;0"/>
+<listEntry value="RegionTombStone;;RegionTombStone;1;0"/>
+<listEntry value="LogRollback;;LogRollback;1;0"/>
+<listEntry value="WillPerformRollback;;FALSE;0;0"/>
+</listAttribute>
+<stringAttribute key="modelParameterContraint" value=""/>
+<listAttribute key="modelParameterDefinitions"/>
+<stringAttribute key="modelParameterModelValues" value="{}"/>
+<stringAttribute key="modelParameterNewDefinitions" value=""/>
+<intAttribute key="numberOfWorkers" value="2"/>
+<booleanAttribute key="recover" value="false"/>
+<stringAttribute key="result.mail.address" value=""/>
+<intAttribute key="simuAril" value="-1"/>
+<intAttribute key="simuDepth" value="100"/>
+<intAttribute key="simuSeed" value="-1"/>
+<stringAttribute key="specName" value="RaftMerge"/>
+<stringAttribute key="view" value=""/>
+<booleanAttribute key="visualizeStateGraph" value="false"/>
+</launchConfiguration>

--- a/RaftMerge/RaftMerge.toolbox/RaftMerge___Test1.launch
+++ b/RaftMerge/RaftMerge.toolbox/RaftMerge___Test1.launch
@@ -24,12 +24,8 @@
 <booleanAttribute key="modelCorrectnessCheckDeadlock" value="true"/>
 <listAttribute key="modelCorrectnessInvariants">
 <listEntry value="1TypeInvariant"/>
-<listEntry value="1OneLeaderInvariant"/>
-<listEntry value="1AppendEntriesMessageInvariant"/>
-<listEntry value="1LogInvariant"/>
-<listEntry value="1ApplyIndexInvariant"/>
-<listEntry value="1RegionApplyInvariant"/>
-<listEntry value="1MergeLogInvariant"/>
+<listEntry value="1SimpliedRaftInvariant"/>
+<listEntry value="1RaftMergeInvariant"/>
 </listAttribute>
 <listAttribute key="modelCorrectnessProperties"/>
 <stringAttribute key="modelExpressionEval" value=""/>

--- a/RaftMerge/RaftMerge.toolbox/RaftMerge___Test2.launch
+++ b/RaftMerge/RaftMerge.toolbox/RaftMerge___Test2.launch
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.lamport.tla.toolbox.tool.tlc.modelCheck">
+<stringAttribute key="TLCCmdLineParameters" value="-workers 2"/>
+<stringAttribute key="configurationName" value="Test2"/>
+<booleanAttribute key="deferLiveness" value="false"/>
+<intAttribute key="dfidDepth" value="100"/>
+<booleanAttribute key="dfidMode" value="false"/>
+<intAttribute key="distributedFPSetCount" value="0"/>
+<stringAttribute key="distributedNetworkInterface" value="172.17.0.1"/>
+<intAttribute key="distributedNodesCount" value="1"/>
+<stringAttribute key="distributedTLC" value="off"/>
+<stringAttribute key="distributedTLCVMArgs" value=""/>
+<intAttribute key="fpBits" value="1"/>
+<intAttribute key="fpIndex" value="1"/>
+<intAttribute key="maxHeapSize" value="25"/>
+<intAttribute key="maxSetSize" value="1000000"/>
+<booleanAttribute key="mcMode" value="true"/>
+<stringAttribute key="modelBehaviorInit" value=""/>
+<stringAttribute key="modelBehaviorNext" value=""/>
+<stringAttribute key="modelBehaviorSpec" value="Spec"/>
+<intAttribute key="modelBehaviorSpecType" value="1"/>
+<stringAttribute key="modelBehaviorVars" value="client_requests_index, messages, raft, region"/>
+<stringAttribute key="modelComments" value=""/>
+<booleanAttribute key="modelCorrectnessCheckDeadlock" value="true"/>
+<listAttribute key="modelCorrectnessInvariants">
+<listEntry value="1TypeInvariant"/>
+<listEntry value="1OneLeaderInvariant"/>
+<listEntry value="1AppendEntriesMessageInvariant"/>
+<listEntry value="1LogInvariant"/>
+<listEntry value="1ApplyIndexInvariant"/>
+<listEntry value="1RegionApplyInvariant"/>
+<listEntry value="1MergeLogInvariant"/>
+</listAttribute>
+<listAttribute key="modelCorrectnessProperties"/>
+<stringAttribute key="modelExpressionEval" value=""/>
+<stringAttribute key="modelParameterActionConstraint" value=""/>
+<listAttribute key="modelParameterConstants">
+<listEntry value="LeaderA;;1;0;0"/>
+<listEntry value="LeaderB;;1;0;0"/>
+<listEntry value="Store;;{1,2};0;0"/>
+<listEntry value="RegionA;;RegionA;1;0"/>
+<listEntry value="RegionB;;RegionB;1;0"/>
+<listEntry value="AppendEntriesReply;;AppendEntriesReply;1;0"/>
+<listEntry value="Region;;{RegionA, RegionB};0;0"/>
+<listEntry value="AppendEntriesRequest;;AppendEntriesRequest;1;0"/>
+<listEntry value="MaxClientRequests;;2;0;0"/>
+<listEntry value="QuorumSize;;1;0;0"/>
+<listEntry value="LogNormal;;LogNormal;1;0"/>
+<listEntry value="RegionNormal;;RegionNormal;1;0"/>
+<listEntry value="LogPreMerge;;LogPreMerge;1;0"/>
+<listEntry value="LogMerge;;LogMerge;1;0"/>
+<listEntry value="RegionMerging;;RegionMerging;1;0"/>
+<listEntry value="RegionTombStone;;RegionTombStone;1;0"/>
+<listEntry value="LogRollback;;LogRollback;1;0"/>
+<listEntry value="WillPerformRollback;;FALSE;0;0"/>
+</listAttribute>
+<stringAttribute key="modelParameterContraint" value=""/>
+<listAttribute key="modelParameterDefinitions"/>
+<stringAttribute key="modelParameterModelValues" value="{}"/>
+<stringAttribute key="modelParameterNewDefinitions" value=""/>
+<intAttribute key="numberOfWorkers" value="2"/>
+<booleanAttribute key="recover" value="false"/>
+<stringAttribute key="result.mail.address" value=""/>
+<intAttribute key="simuAril" value="-1"/>
+<intAttribute key="simuDepth" value="100"/>
+<intAttribute key="simuSeed" value="-1"/>
+<stringAttribute key="specName" value="RaftMerge"/>
+<stringAttribute key="view" value=""/>
+<booleanAttribute key="visualizeStateGraph" value="false"/>
+</launchConfiguration>

--- a/RaftMerge/RaftMerge.toolbox/RaftMerge___Test2.launch
+++ b/RaftMerge/RaftMerge.toolbox/RaftMerge___Test2.launch
@@ -24,12 +24,8 @@
 <booleanAttribute key="modelCorrectnessCheckDeadlock" value="true"/>
 <listAttribute key="modelCorrectnessInvariants">
 <listEntry value="1TypeInvariant"/>
-<listEntry value="1OneLeaderInvariant"/>
-<listEntry value="1AppendEntriesMessageInvariant"/>
-<listEntry value="1LogInvariant"/>
-<listEntry value="1ApplyIndexInvariant"/>
-<listEntry value="1RegionApplyInvariant"/>
-<listEntry value="1MergeLogInvariant"/>
+<listEntry value="1SimpliedRaftInvariant"/>
+<listEntry value="1RaftMergeInvariant"/>
 </listAttribute>
 <listAttribute key="modelCorrectnessProperties"/>
 <stringAttribute key="modelExpressionEval" value=""/>

--- a/RaftMerge/RaftMerge.toolbox/RaftMerge___Test3.launch
+++ b/RaftMerge/RaftMerge.toolbox/RaftMerge___Test3.launch
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.lamport.tla.toolbox.tool.tlc.modelCheck">
+<stringAttribute key="TLCCmdLineParameters" value="-workers 2"/>
+<stringAttribute key="configurationName" value="Test3"/>
+<booleanAttribute key="deferLiveness" value="false"/>
+<intAttribute key="dfidDepth" value="100"/>
+<booleanAttribute key="dfidMode" value="false"/>
+<intAttribute key="distributedFPSetCount" value="0"/>
+<stringAttribute key="distributedNetworkInterface" value="172.17.0.1"/>
+<intAttribute key="distributedNodesCount" value="1"/>
+<stringAttribute key="distributedTLC" value="off"/>
+<stringAttribute key="distributedTLCVMArgs" value=""/>
+<intAttribute key="fpBits" value="1"/>
+<intAttribute key="fpIndex" value="1"/>
+<intAttribute key="maxHeapSize" value="25"/>
+<intAttribute key="maxSetSize" value="1000000"/>
+<booleanAttribute key="mcMode" value="true"/>
+<stringAttribute key="modelBehaviorInit" value=""/>
+<stringAttribute key="modelBehaviorNext" value=""/>
+<stringAttribute key="modelBehaviorSpec" value="Spec"/>
+<intAttribute key="modelBehaviorSpecType" value="1"/>
+<stringAttribute key="modelBehaviorVars" value="client_requests_index, messages, raft, region"/>
+<stringAttribute key="modelComments" value=""/>
+<booleanAttribute key="modelCorrectnessCheckDeadlock" value="true"/>
+<listAttribute key="modelCorrectnessInvariants">
+<listEntry value="1TypeInvariant"/>
+<listEntry value="1OneLeaderInvariant"/>
+<listEntry value="1AppendEntriesMessageInvariant"/>
+<listEntry value="1LogInvariant"/>
+<listEntry value="1ApplyIndexInvariant"/>
+<listEntry value="1RegionApplyInvariant"/>
+<listEntry value="1MergeLogInvariant"/>
+</listAttribute>
+<listAttribute key="modelCorrectnessProperties"/>
+<stringAttribute key="modelExpressionEval" value=""/>
+<stringAttribute key="modelParameterActionConstraint" value=""/>
+<listAttribute key="modelParameterConstants">
+<listEntry value="LeaderA;;1;0;0"/>
+<listEntry value="LeaderB;;2;0;0"/>
+<listEntry value="Store;;{1,2};0;0"/>
+<listEntry value="RegionA;;RegionA;1;0"/>
+<listEntry value="RegionB;;RegionB;1;0"/>
+<listEntry value="AppendEntriesReply;;AppendEntriesReply;1;0"/>
+<listEntry value="Region;;{RegionA, RegionB};0;0"/>
+<listEntry value="AppendEntriesRequest;;AppendEntriesRequest;1;0"/>
+<listEntry value="MaxClientRequests;;2;0;0"/>
+<listEntry value="QuorumSize;;1;0;0"/>
+<listEntry value="LogNormal;;LogNormal;1;0"/>
+<listEntry value="RegionNormal;;RegionNormal;1;0"/>
+<listEntry value="LogPreMerge;;LogPreMerge;1;0"/>
+<listEntry value="LogMerge;;LogMerge;1;0"/>
+<listEntry value="RegionMerging;;RegionMerging;1;0"/>
+<listEntry value="RegionTombStone;;RegionTombStone;1;0"/>
+<listEntry value="LogRollback;;LogRollback;1;0"/>
+<listEntry value="WillPerformRollback;;TRUE;0;0"/>
+</listAttribute>
+<stringAttribute key="modelParameterContraint" value=""/>
+<listAttribute key="modelParameterDefinitions"/>
+<stringAttribute key="modelParameterModelValues" value="{}"/>
+<stringAttribute key="modelParameterNewDefinitions" value=""/>
+<intAttribute key="numberOfWorkers" value="2"/>
+<booleanAttribute key="recover" value="false"/>
+<stringAttribute key="result.mail.address" value=""/>
+<intAttribute key="simuAril" value="-1"/>
+<intAttribute key="simuDepth" value="100"/>
+<intAttribute key="simuSeed" value="-1"/>
+<stringAttribute key="specName" value="RaftMerge"/>
+<stringAttribute key="view" value=""/>
+<booleanAttribute key="visualizeStateGraph" value="false"/>
+</launchConfiguration>

--- a/RaftMerge/RaftMerge.toolbox/RaftMerge___Test3.launch
+++ b/RaftMerge/RaftMerge.toolbox/RaftMerge___Test3.launch
@@ -24,12 +24,8 @@
 <booleanAttribute key="modelCorrectnessCheckDeadlock" value="true"/>
 <listAttribute key="modelCorrectnessInvariants">
 <listEntry value="1TypeInvariant"/>
-<listEntry value="1OneLeaderInvariant"/>
-<listEntry value="1AppendEntriesMessageInvariant"/>
-<listEntry value="1LogInvariant"/>
-<listEntry value="1ApplyIndexInvariant"/>
-<listEntry value="1RegionApplyInvariant"/>
-<listEntry value="1MergeLogInvariant"/>
+<listEntry value="1SimpliedRaftInvariant"/>
+<listEntry value="1RaftMergeInvariant"/>
 </listAttribute>
 <listAttribute key="modelCorrectnessProperties"/>
 <stringAttribute key="modelExpressionEval" value=""/>

--- a/RaftMerge/RaftMerge.toolbox/RaftMerge___Test4.launch
+++ b/RaftMerge/RaftMerge.toolbox/RaftMerge___Test4.launch
@@ -1,0 +1,70 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.lamport.tla.toolbox.tool.tlc.modelCheck">
+<stringAttribute key="TLCCmdLineParameters" value="-workers 2"/>
+<stringAttribute key="configurationName" value="Test4"/>
+<booleanAttribute key="deferLiveness" value="false"/>
+<intAttribute key="dfidDepth" value="100"/>
+<booleanAttribute key="dfidMode" value="false"/>
+<intAttribute key="distributedFPSetCount" value="0"/>
+<stringAttribute key="distributedNetworkInterface" value="172.17.0.1"/>
+<intAttribute key="distributedNodesCount" value="1"/>
+<stringAttribute key="distributedTLC" value="off"/>
+<stringAttribute key="distributedTLCVMArgs" value=""/>
+<intAttribute key="fpBits" value="1"/>
+<intAttribute key="fpIndex" value="1"/>
+<intAttribute key="maxHeapSize" value="25"/>
+<intAttribute key="maxSetSize" value="1000000"/>
+<booleanAttribute key="mcMode" value="true"/>
+<stringAttribute key="modelBehaviorInit" value=""/>
+<stringAttribute key="modelBehaviorNext" value=""/>
+<stringAttribute key="modelBehaviorSpec" value="Spec"/>
+<intAttribute key="modelBehaviorSpecType" value="1"/>
+<stringAttribute key="modelBehaviorVars" value="client_requests_index, messages, raft, region"/>
+<stringAttribute key="modelComments" value=""/>
+<booleanAttribute key="modelCorrectnessCheckDeadlock" value="true"/>
+<listAttribute key="modelCorrectnessInvariants">
+<listEntry value="1TypeInvariant"/>
+<listEntry value="1OneLeaderInvariant"/>
+<listEntry value="1AppendEntriesMessageInvariant"/>
+<listEntry value="1LogInvariant"/>
+<listEntry value="1ApplyIndexInvariant"/>
+<listEntry value="1RegionApplyInvariant"/>
+<listEntry value="1MergeLogInvariant"/>
+</listAttribute>
+<listAttribute key="modelCorrectnessProperties"/>
+<stringAttribute key="modelExpressionEval" value=""/>
+<stringAttribute key="modelParameterActionConstraint" value=""/>
+<listAttribute key="modelParameterConstants">
+<listEntry value="LeaderA;;1;0;0"/>
+<listEntry value="LeaderB;;1;0;0"/>
+<listEntry value="Store;;{1,2};0;0"/>
+<listEntry value="RegionA;;RegionA;1;0"/>
+<listEntry value="RegionB;;RegionB;1;0"/>
+<listEntry value="AppendEntriesReply;;AppendEntriesReply;1;0"/>
+<listEntry value="Region;;{RegionA, RegionB};0;0"/>
+<listEntry value="AppendEntriesRequest;;AppendEntriesRequest;1;0"/>
+<listEntry value="MaxClientRequests;;2;0;0"/>
+<listEntry value="QuorumSize;;1;0;0"/>
+<listEntry value="LogNormal;;LogNormal;1;0"/>
+<listEntry value="RegionNormal;;RegionNormal;1;0"/>
+<listEntry value="LogPreMerge;;LogPreMerge;1;0"/>
+<listEntry value="LogMerge;;LogMerge;1;0"/>
+<listEntry value="RegionMerging;;RegionMerging;1;0"/>
+<listEntry value="RegionTombStone;;RegionTombStone;1;0"/>
+<listEntry value="LogRollback;;LogRollback;1;0"/>
+<listEntry value="WillPerformRollback;;TRUE;0;0"/>
+</listAttribute>
+<stringAttribute key="modelParameterContraint" value=""/>
+<listAttribute key="modelParameterDefinitions"/>
+<stringAttribute key="modelParameterModelValues" value="{}"/>
+<stringAttribute key="modelParameterNewDefinitions" value=""/>
+<intAttribute key="numberOfWorkers" value="2"/>
+<booleanAttribute key="recover" value="false"/>
+<stringAttribute key="result.mail.address" value=""/>
+<intAttribute key="simuAril" value="-1"/>
+<intAttribute key="simuDepth" value="100"/>
+<intAttribute key="simuSeed" value="-1"/>
+<stringAttribute key="specName" value="RaftMerge"/>
+<stringAttribute key="view" value=""/>
+<booleanAttribute key="visualizeStateGraph" value="false"/>
+</launchConfiguration>

--- a/RaftMerge/RaftMerge.toolbox/RaftMerge___Test4.launch
+++ b/RaftMerge/RaftMerge.toolbox/RaftMerge___Test4.launch
@@ -24,12 +24,8 @@
 <booleanAttribute key="modelCorrectnessCheckDeadlock" value="true"/>
 <listAttribute key="modelCorrectnessInvariants">
 <listEntry value="1TypeInvariant"/>
-<listEntry value="1OneLeaderInvariant"/>
-<listEntry value="1AppendEntriesMessageInvariant"/>
-<listEntry value="1LogInvariant"/>
-<listEntry value="1ApplyIndexInvariant"/>
-<listEntry value="1RegionApplyInvariant"/>
-<listEntry value="1MergeLogInvariant"/>
+<listEntry value="1SimpliedRaftInvariant"/>
+<listEntry value="1RaftMergeInvariant"/>
 </listAttribute>
 <listAttribute key="modelCorrectnessProperties"/>
 <stringAttribute key="modelExpressionEval" value=""/>

--- a/RaftMerge/Test1.cfg
+++ b/RaftMerge/Test1.cfg
@@ -1,0 +1,31 @@
+CONSTANT
+  AppendEntriesReply = AppendEntriesReply
+  AppendEntriesRequest = AppendEntriesRequest
+
+  LogMerge = LogMerge
+  LogNormal = LogNormal
+  LogPreMerge = LogPreMerge
+  LogRollback = LogRollback
+
+  RegionA = RegionA
+  RegionB = RegionB
+
+  RegionMerging = RegionMerging
+  RegionNormal = RegionNormal
+  RegionTombStone = RegionTombStone
+
+  Region = {RegionA, RegionB}
+  LeaderA = 1
+  LeaderB = 2
+  MaxClientRequests = 2
+  QuorumSize = 1
+  Store = {1, 2}
+  WillPerformRollback = FALSE
+
+SPECIFICATION
+  Spec
+
+INVARIANT
+  TypeInvariant
+  SimpliedRaftInvariant
+  RaftMergeInvariant

--- a/RaftMerge/Test2.cfg
+++ b/RaftMerge/Test2.cfg
@@ -1,0 +1,31 @@
+CONSTANT
+  AppendEntriesReply = AppendEntriesReply
+  AppendEntriesRequest = AppendEntriesRequest
+
+  LogMerge = LogMerge
+  LogNormal = LogNormal
+  LogPreMerge = LogPreMerge
+  LogRollback = LogRollback
+
+  RegionA = RegionA
+  RegionB = RegionB
+
+  RegionMerging = RegionMerging
+  RegionNormal = RegionNormal
+  RegionTombStone = RegionTombStone
+
+  Region = {RegionA, RegionB}
+  LeaderA = 1
+  LeaderB = 1
+  MaxClientRequests = 2
+  QuorumSize = 1
+  Store = {1, 2}
+  WillPerformRollback = FALSE
+
+SPECIFICATION
+  Spec
+
+INVARIANT
+  TypeInvariant
+  SimpliedRaftInvariant
+  RaftMergeInvariant

--- a/RaftMerge/Test3.cfg
+++ b/RaftMerge/Test3.cfg
@@ -1,0 +1,31 @@
+CONSTANT
+  AppendEntriesReply = AppendEntriesReply
+  AppendEntriesRequest = AppendEntriesRequest
+
+  LogMerge = LogMerge
+  LogNormal = LogNormal
+  LogPreMerge = LogPreMerge
+  LogRollback = LogRollback
+
+  RegionA = RegionA
+  RegionB = RegionB
+
+  RegionMerging = RegionMerging
+  RegionNormal = RegionNormal
+  RegionTombStone = RegionTombStone
+
+  Region = {RegionA, RegionB}
+  LeaderA = 1
+  LeaderB = 2
+  MaxClientRequests = 2
+  QuorumSize = 1
+  Store = {1, 2}
+  WillPerformRollback = TRUE
+
+SPECIFICATION
+  Spec
+
+INVARIANT
+  TypeInvariant
+  SimpliedRaftInvariant
+  RaftMergeInvariant

--- a/RaftMerge/Test4.cfg
+++ b/RaftMerge/Test4.cfg
@@ -1,0 +1,31 @@
+CONSTANT
+  AppendEntriesReply = AppendEntriesReply
+  AppendEntriesRequest = AppendEntriesRequest
+
+  LogMerge = LogMerge
+  LogNormal = LogNormal
+  LogPreMerge = LogPreMerge
+  LogRollback = LogRollback
+
+  RegionA = RegionA
+  RegionB = RegionB
+
+  RegionMerging = RegionMerging
+  RegionNormal = RegionNormal
+  RegionTombStone = RegionTombStone
+
+  Region = {RegionA, RegionB}
+  LeaderA = 1
+  LeaderB = 1
+  MaxClientRequests = 2
+  QuorumSize = 1
+  Store = {1, 2}
+  WillPerformRollback = TRUE
+
+SPECIFICATION
+  Spec
+
+INVARIANT
+  TypeInvariant
+  SimpliedRaftInvariant
+  RaftMergeInvariant


### PR DESCRIPTION
Implemented rollback. This is controlled by a flag rather than epoch change. When rollback is enabled, merging will never happen, and leader A will try to perform rollback on B.

Also add 4 TLC models.
* No rollback, leader A and B not on the same store.
* No rollback, leader A and B on the same store.
* Rollback, leader A and B not on the same store.
* Rollback, leader A and B on the same store.

This PR concludes everything.