### PR TITLE
concurrent percolator: implementation.

### DIFF
--- a/Percolator/Concurrent/ConcurrentPercolator.cfg
+++ b/Percolator/Concurrent/ConcurrentPercolator.cfg
@@ -18,3 +18,4 @@ INVARIANT
   CommittedConsistency
   AbortedConsistency
   SnapshotIsolation
+  UniqueWrite

--- a/Percolator/Concurrent/ConcurrentPercolator.cfg
+++ b/Percolator/Concurrent/ConcurrentPercolator.cfg
@@ -17,5 +17,6 @@ INVARIANT
   LockConsistency
   CommittedConsistency
   AbortedConsistency
-  SnapshotIsolation
+  RollbackConsistency
   UniqueWrite
+  SnapshotIsolation

--- a/Percolator/Concurrent/ConcurrentPercolator.toolbox/ConcurrentPercolator___ConcurrentPercolatorModel.launch
+++ b/Percolator/Concurrent/ConcurrentPercolator.toolbox/ConcurrentPercolator___ConcurrentPercolatorModel.launch
@@ -28,6 +28,8 @@
 <listEntry value="1LockConsistency"/>
 <listEntry value="1CommittedConsistency"/>
 <listEntry value="1AbortedConsistency"/>
+<listEntry value="1RollbackConsistency"/>
+<listEntry value="1UniqueWrite"/>
 <listEntry value="1SnapshotIsolation"/>
 </listAttribute>
 <listAttribute key="modelCorrectnessProperties"/>


### PR DESCRIPTION
Do concurrent prewrites on primary lock and secondary locks.

Details:
* When resolving lock, if we are going to rollback it, we will leave a rollback record in write column rather than silently discarding data and lock.
* Abort transaction if we find the primary lock is already rolled back.