### PR TITLE
ConcurrentPercolator: remove the pre rollback 

### DIFF
--- a/ConcurrentPercolator/ConcurrentPercolator.tla
+++ b/ConcurrentPercolator/ConcurrentPercolator.tla
@@ -152,7 +152,7 @@ collapsePreRollback(w, ts) ==
 writeRollback(ws, ts) ==
   IF hasRollbackWithDeleted(ws, ts)
   THEN
-     [i \in 1..Len(ws)|->IF isRollbackWithDeleted(ws[i], ts) THEN ws[i] ELSE [ts |-> ws[i].ts, type |-> ws[i].type, is_deleted |-> TRUE]]
+     [i \in 1..Len(ws)|->IF isRollbackWithDeleted(ws[i], ts) THEN ws[i] ELSE [ts |-> ws[i].ts, type |-> ws[i].type, is_deleted |-> FALSE]]
   ELSE
      Append(collapsePreRollback(ws, ts), [ts |-> ts, type |-> "rollback", is_deleted |-> FALSE])
     

--- a/ConcurrentPercolator/ConcurrentPercolator.tla
+++ b/ConcurrentPercolator/ConcurrentPercolator.tla
@@ -83,8 +83,8 @@ hasStaleLock(k, ts) ==
 
 \* Returns the writes with start_ts equals to $ts$.
 findWriteWithStartTS(k, ts) ==
-  {w \in Range(key_write[k]) : (w.type = "write" /\ w.start_ts = ts)}      
-   
+  {w \in Range(key_write[k]) : (w.type = "write" /\ w.start_ts = ts)}
+
 \* Returns the writes with commit_ts equals to $ts$.
 findWriteWithCommitTS(k, ts) ==
   {w \in Range(key_write[k]) : (w.type = "write" /\ w.ts = ts)}

--- a/ConcurrentPercolator/ConcurrentPercolator.tla
+++ b/ConcurrentPercolator/ConcurrentPercolator.tla
@@ -64,8 +64,7 @@ Range(m) ==
   {m[i] : i \in DOMAIN m}  
 
 --------------------------------------------------------------------------------
-\* Checks whether there is a lock of key $k$, whose $ts$ is less or equal than
-\* $ts$.
+\* Checks whether there is a lock of key $k$, whose $ts$ is less than or equal to $ts$.
 hasLockLE(k, ts) ==
   \E l \in key_lock[k] : l.ts <= ts
 
@@ -107,18 +106,18 @@ checkSnapshotIsolation(k, commit_ts) ==
 \* Returns index of $e$ in $seq$ 
 getIndex(seq, e) == CHOOSE n \in DOMAIN seq : seq[n] = e  
 
-\* Returns the value whose $ts$ is the max in all values
+\* Returns the write whose $ts$ is largest
 getWriteWithMaxTS(w) == CHOOSE x \in w : \A y \in w : x.ts >= y.ts
 
 \* Returns the writes with ts less or equal than $ts$ 
 findWriteLessEqualTS(kw, ts) ==
   {w \in Range(kw) : (w.ts <= ts)}  
 
-\* Deletes element whose index equal to $index$ from $seq$
+\* Deletes element whose index in $seq$ equal to $index$
 deleteElement(seq, index)==
   [i \in 1..(Len(seq)-1)|->IF i<index THEN seq[i]ELSE seq[(i+1)]]
 
-\* Removes the pre rollback, whose ts is less or equal than $ts$.
+\* Removes the pre rollback, whose ts is less than or equal to $ts$.
 collapsePreRollback(w, ts) == 
   LET 
      writes == findWriteLessEqualTS(w, ts)


### PR DESCRIPTION
This pr is to verify this https://github.com/pingcap/tikv/pull/3290 

When writing `rollback` to `key_write`, the previous `rollback` with the same key will be deleted first, and the ts of the deleted `rollback` must be less than or equal to the `rollback` to be written.  

PTAL @foreverbell @siddontang @GregoryIan @zhangjinpeng1987 