### PR TITLE
collapserollback: move collapserollback optimization to a separate directory

### DIFF
--- a/CollapseRollbacks/CollapseRollbacks.tla
+++ b/CollapseRollbacks/CollapseRollbacks.tla
@@ -1,4 +1,4 @@
--------------------------- MODULE ConcurrentPercolator -------------------------
+-------------------------- MODULE CollapseRollbacks -------------------------
 
 EXTENDS Integers, FiniteSets, Sequences, TLC
 
@@ -64,8 +64,7 @@ Range(m) ==
   {m[i] : i \in DOMAIN m}
 
 --------------------------------------------------------------------------------
-\* Checks whether there is a lock of key $k$, whose $ts$ is less or equal than
-\* $ts$.
+\* Checks whether there is a lock of key $k$, whose $ts$ is less than or equal to $ts$.
 hasLockLE(k, ts) ==
   \E l \in key_lock[k] : l.ts <= ts
 
@@ -90,9 +89,23 @@ findWriteWithStartTS(k, ts) ==
 findWriteWithCommitTS(k, ts) ==
   {w \in Range(key_write[k]) : (w.type = "write" /\ w.ts = ts)}
 
-\* Returns TRUE if there is a rollback for key $k$ at timestamp $ts$.
+\* Returns TRUE if there is a rollback for key $k$ that is not deleted logically at timestamp $ts$.
+hasRollbackNotDeleted(k, ts) ==
+  {r \in Range(key_write[k]) : (r.type = "rollback" /\ r.is_deleted = FALSE /\ r.ts = ts )} # {}
+
+\* Returns TRUE if there is a rollback for key $k$ at timestamp $ts$
 hasRollback(k, ts) ==
   {r \in Range(key_write[k]) : (r.type = "rollback" /\ r.ts = ts)} # {}
+
+\* Returns TRUE if the write is rollback with ts equal to $ts$
+\* and this rollback is marked as deleted.
+isRollbackWithDeleted(w, ts) ==
+  (w.type = "rollback" /\ w.ts = ts /\ w.is_deleted = TRUE)
+
+\* Returns TRUE if there is a rollback at timestamp $ts$
+\* and this rollback is marked as deleted.
+hasRollbackWithDeleted(ws, ts) ==
+  {r \in Range(ws) : isRollbackWithDeleted(r, ts)} # {}
 
 \* Updates $key_si$ for key $k$. If a new version of key $k$ is committed with
 \* $commit_ts$ < last read timestamp, consider the snapshot isolation invariant
@@ -104,6 +117,45 @@ checkSnapshotIsolation(k, commit_ts) ==
   ELSE
     UNCHANGED <<key_si>>
 
+\* Returns the writes with ts less than or equal to $ts$ and is not deleted logically
+findWriteLessEqualTS(kw, ts) ==
+  {w \in Range(kw) : (w.ts <= ts /\ w.is_deleted = FALSE)}
+
+\* Returns the write whose $ts$ is the max in all writes
+getWriteWithMaxTS(w) == CHOOSE x \in w : \A y \in w : x.ts >= y.ts
+
+\* Deletes element from $seq$ logically
+logicalDeleteElement(seq, e)==
+  [i \in 1..Len(seq)|->IF seq[i] # e THEN seq[i] ELSE [ts |-> seq[i].ts, type |-> seq[i].type, is_deleted |-> TRUE]]
+
+\* Removes the pre rollback, whose ts is less than or equal to $ts$.
+collapsePreRollback(w, ts) ==
+   LET
+      writes == findWriteLessEqualTS(w, ts)
+   IN
+      IF writes # {}
+      THEN
+          LET
+             maxTsWrite == getWriteWithMaxTS(writes)
+          IN
+             IF maxTsWrite.type = "rollback"
+             THEN
+                 logicalDeleteElement(w, maxTsWrite)
+             ELSE
+                 w
+      ELSE
+          w
+
+\* Writes rollback record to key write.
+\* If the rollback with the ts equal to $ts$ exists and is marked as deleted,
+\* which will be overwritten by the new rollback.
+writeRollback(ws, ts) ==
+  IF hasRollbackWithDeleted(ws, ts)
+  THEN
+     [i \in 1..Len(ws)|->IF isRollbackWithDeleted(ws[i], ts) THEN ws[i] ELSE [ts |-> ws[i].ts, type |-> ws[i].type, is_deleted |-> FALSE]]
+  ELSE
+     Append(collapsePreRollback(ws, ts), [ts |-> ts, type |-> "rollback", is_deleted |-> FALSE])
+    
 \* Cleans up a stale lock and its data.
 \* If the lock is a secondary lock, and the assoicated primary lock is cleaned
 \* up, we can clean up the lock and do,
@@ -115,8 +167,7 @@ cleanupStaleLock(k, ts) ==
     eraseLock(key, l) ==
       /\ key_data' = [key_data EXCEPT ![key] = @ \ {[ts |-> l.ts]}]
       /\ key_lock' = [key_lock EXCEPT ![key] = @ \ {l}]
-      /\ key_write' = [key_write EXCEPT ![key] =
-                         Append(@, [ts |-> l.ts, type |-> "rollback"])]
+      /\ key_write' = [key_write EXCEPT ![key] = writeRollback(key_write[key], l.ts)]
   IN
     \E l \in key_lock[k] :
       /\ isStaleLock(l, ts)
@@ -134,7 +185,7 @@ cleanupStaleLock(k, ts) ==
                     \* the primary key is not committed, clean up the data.
                     \* Note we should always clean up the corresponding primary
                     \* lock first, then this secondary lock.
-                    IF hasRollback(l.primary, l.ts) = FALSE
+                    IF hasRollbackNotDeleted(l.primary, l.ts) = FALSE
                     THEN
                       /\ eraseLock(l.primary, l)
                       /\ UNCHANGED <<key_si>>
@@ -218,7 +269,8 @@ commitPrimary(c) ==
     /\ key_write' = [key_write EXCEPT ![primary] =
                       Append(@, [ts |-> commit_ts,
                                  type |-> "write",
-                                 start_ts |-> start_ts])]
+                                 start_ts |-> start_ts,
+                                 is_deleted |-> FALSE])]
     /\ key_lock' = [key_lock EXCEPT ![primary] = @ \ {[ts |-> start_ts,
                                                        primary |-> primary]}]
     /\ checkSnapshotIsolation(primary, commit_ts)
@@ -330,8 +382,8 @@ KeyLockTypeInv ==
   key_lock \in [KEY -> SUBSET [ts : Nat, primary : KEY]]
 
 KeyWriteTypeInv ==
-  key_write \in [KEY -> Seq([ts : Nat, type : {"write"}, start_ts : Nat] \union
-                            [ts : Nat, type : {"rollback"}])
+  key_write \in [KEY -> Seq([ts : Nat, type : {"write"}, start_ts : Nat, is_deleted: BOOLEAN] \union
+                            [ts : Nat, type : {"rollback"}, is_deleted: BOOLEAN])
                 ]
 
 KeyLastReadTsTypeInv ==
@@ -387,7 +439,7 @@ CommittedConsistency ==
       commit_ts == client_ts[c].commit_ts
       primary == client_key[c].primary
       secondary == client_key[c].secondary
-      w == [ts |-> commit_ts, type |-> "write", start_ts |-> start_ts]
+      w == [ts |-> commit_ts, type |-> "write", start_ts |-> start_ts, is_deleted |-> FALSE]
     IN
       client_state[c] = "committed" =>
         \* The primary key lock must be cleaned up, and no any older lock.

--- a/CollapseRollbacks/CollapseRollbacks.toolbox/CollapseRollbacks___Test1.launch
+++ b/CollapseRollbacks/CollapseRollbacks.toolbox/CollapseRollbacks___Test1.launch
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.lamport.tla.toolbox.tool.tlc.modelCheck">
+<stringAttribute key="TLCCmdLineParameters" value=""/>
+<stringAttribute key="configurationName" value="Test1"/>
+<booleanAttribute key="deferLiveness" value="false"/>
+<intAttribute key="dfidDepth" value="100"/>
+<booleanAttribute key="dfidMode" value="false"/>
+<intAttribute key="distributedFPSetCount" value="0"/>
+<stringAttribute key="distributedNetworkInterface" value="192.168.198.226"/>
+<intAttribute key="distributedNodesCount" value="1"/>
+<stringAttribute key="distributedTLC" value="off"/>
+<stringAttribute key="distributedTLCVMArgs" value=""/>
+<intAttribute key="fpBits" value="1"/>
+<intAttribute key="fpIndex" value="1"/>
+<intAttribute key="maxHeapSize" value="25"/>
+<intAttribute key="maxSetSize" value="1000000"/>
+<booleanAttribute key="mcMode" value="true"/>
+<stringAttribute key="modelBehaviorInit" value=""/>
+<stringAttribute key="modelBehaviorNext" value=""/>
+<stringAttribute key="modelBehaviorSpec" value="PercolatorSpec"/>
+<intAttribute key="modelBehaviorSpecType" value="1"/>
+<stringAttribute key="modelBehaviorVars" value="key_data, key_lock, next_ts, client_state, key_last_read_ts, client_key, client_ts, key_si, key_write"/>
+<stringAttribute key="modelComments" value=""/>
+<booleanAttribute key="modelCorrectnessCheckDeadlock" value="false"/>
+<listAttribute key="modelCorrectnessInvariants">
+<listEntry value="1TypeInvariant"/>
+<listEntry value="1WriteConsistency"/>
+<listEntry value="1LockConsistency"/>
+<listEntry value="1CommittedConsistency"/>
+<listEntry value="1AbortedConsistency"/>
+<listEntry value="1RollbackConsistency"/>
+<listEntry value="1UniqueWrite"/>
+<listEntry value="1SnapshotIsolation"/>
+</listAttribute>
+<listAttribute key="modelCorrectnessProperties"/>
+<stringAttribute key="modelExpressionEval" value=""/>
+<stringAttribute key="modelParameterActionConstraint" value=""/>
+<listAttribute key="modelParameterConstants">
+<listEntry value="KEY;;{1, 2, 3};0;0"/>
+<listEntry value="CLIENT_PRIMARY_KEY;;c1 :&gt; 1 @@ c2 :&gt; 1 @@ c3 :&gt; 1;0;0"/>
+<listEntry value="CLIENT;;{c1, c2, c3};1;1"/>
+</listAttribute>
+<stringAttribute key="modelParameterContraint" value=""/>
+<listAttribute key="modelParameterDefinitions"/>
+<stringAttribute key="modelParameterModelValues" value="{}"/>
+<stringAttribute key="modelParameterNewDefinitions" value=""/>
+<intAttribute key="numberOfWorkers" value="4"/>
+<booleanAttribute key="recover" value="false"/>
+<stringAttribute key="result.mail.address" value=""/>
+<intAttribute key="simuAril" value="-1"/>
+<intAttribute key="simuDepth" value="100"/>
+<intAttribute key="simuSeed" value="-1"/>
+<stringAttribute key="specName" value="CollapseRollbacks"/>
+<stringAttribute key="view" value=""/>
+<booleanAttribute key="visualizeStateGraph" value="false"/>
+</launchConfiguration>

--- a/CollapseRollbacks/CollapseRollbacks.toolbox/CollapseRollbacks___Test2.launch
+++ b/CollapseRollbacks/CollapseRollbacks.toolbox/CollapseRollbacks___Test2.launch
@@ -1,0 +1,56 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<launchConfiguration type="org.lamport.tla.toolbox.tool.tlc.modelCheck">
+<stringAttribute key="TLCCmdLineParameters" value=""/>
+<stringAttribute key="configurationName" value="Test2"/>
+<booleanAttribute key="deferLiveness" value="false"/>
+<intAttribute key="dfidDepth" value="100"/>
+<booleanAttribute key="dfidMode" value="false"/>
+<intAttribute key="distributedFPSetCount" value="0"/>
+<stringAttribute key="distributedNetworkInterface" value="192.168.198.226"/>
+<intAttribute key="distributedNodesCount" value="1"/>
+<stringAttribute key="distributedTLC" value="off"/>
+<stringAttribute key="distributedTLCVMArgs" value=""/>
+<intAttribute key="fpBits" value="1"/>
+<intAttribute key="fpIndex" value="1"/>
+<intAttribute key="maxHeapSize" value="25"/>
+<intAttribute key="maxSetSize" value="1000000"/>
+<booleanAttribute key="mcMode" value="true"/>
+<stringAttribute key="modelBehaviorInit" value=""/>
+<stringAttribute key="modelBehaviorNext" value=""/>
+<stringAttribute key="modelBehaviorSpec" value="PercolatorSpec"/>
+<intAttribute key="modelBehaviorSpecType" value="1"/>
+<stringAttribute key="modelBehaviorVars" value="key_data, key_lock, next_ts, client_state, key_last_read_ts, client_key, client_ts, key_si, key_write"/>
+<stringAttribute key="modelComments" value=""/>
+<booleanAttribute key="modelCorrectnessCheckDeadlock" value="false"/>
+<listAttribute key="modelCorrectnessInvariants">
+<listEntry value="1TypeInvariant"/>
+<listEntry value="1WriteConsistency"/>
+<listEntry value="1LockConsistency"/>
+<listEntry value="1CommittedConsistency"/>
+<listEntry value="1AbortedConsistency"/>
+<listEntry value="1RollbackConsistency"/>
+<listEntry value="1UniqueWrite"/>
+<listEntry value="1SnapshotIsolation"/>
+</listAttribute>
+<listAttribute key="modelCorrectnessProperties"/>
+<stringAttribute key="modelExpressionEval" value=""/>
+<stringAttribute key="modelParameterActionConstraint" value=""/>
+<listAttribute key="modelParameterConstants">
+<listEntry value="KEY;;{1, 2};0;0"/>
+<listEntry value="CLIENT_PRIMARY_KEY;;c1 :&gt; 1 @@ c2 :&gt; 2;0;0"/>
+<listEntry value="CLIENT;;{c1, c2};1;1"/>
+</listAttribute>
+<stringAttribute key="modelParameterContraint" value=""/>
+<listAttribute key="modelParameterDefinitions"/>
+<stringAttribute key="modelParameterModelValues" value="{}"/>
+<stringAttribute key="modelParameterNewDefinitions" value=""/>
+<intAttribute key="numberOfWorkers" value="4"/>
+<booleanAttribute key="recover" value="false"/>
+<stringAttribute key="result.mail.address" value=""/>
+<intAttribute key="simuAril" value="-1"/>
+<intAttribute key="simuDepth" value="100"/>
+<intAttribute key="simuSeed" value="-1"/>
+<stringAttribute key="specName" value="CollapseRollbacks"/>
+<stringAttribute key="view" value=""/>
+<booleanAttribute key="visualizeStateGraph" value="false"/>
+</launchConfiguration>

--- a/CollapseRollbacks/Test1.cfg
+++ b/CollapseRollbacks/Test1.cfg
@@ -1,0 +1,25 @@
+\* See Test1.tla.
+
+CONSTANT
+  c1 = c1
+  c2 = c2
+  c3 = c3
+  KEY <- Key
+  CLIENT <- Client
+  CLIENT_PRIMARY_KEY <- ClientPrimaryKey
+
+SYMMETRY
+  Symmetry
+
+SPECIFICATION
+  PercolatorSpec
+
+INVARIANT
+  TypeInvariant
+  WriteConsistency
+  LockConsistency
+  CommittedConsistency
+  AbortedConsistency
+  RollbackConsistency
+  UniqueWrite
+  SnapshotIsolation

--- a/CollapseRollbacks/Test1.tla
+++ b/CollapseRollbacks/Test1.tla
@@ -1,0 +1,16 @@
+--------------------------------- MODULE Test1 ---------------------------------
+
+EXTENDS CollapseRollbacks, TLC
+
+\* We use one table with 3 keys and 3 concurrent clients for TLC model checking.
+\* These 3 clients have the same primary key, so they are considered symmetric.
+
+CONSTANTS c1, c2, c3
+
+Key == {1, 2, 3}
+Client == {c1, c2, c3}
+ClientPrimaryKey == c1 :> 1 @@ c2 :> 1 @@ c3 :> 1
+
+Symmetry == Permutations(Client)
+
+================================================================================

--- a/CollapseRollbacks/Test2.cfg
+++ b/CollapseRollbacks/Test2.cfg
@@ -1,0 +1,21 @@
+\* See Test2.tla.
+
+CONSTANT
+  c1 = c1
+  c2 = c2
+  KEY <- Key
+  CLIENT <- Client
+  CLIENT_PRIMARY_KEY <- ClientPrimaryKey
+
+SPECIFICATION
+  PercolatorSpec
+
+INVARIANT
+  TypeInvariant
+  WriteConsistency
+  LockConsistency
+  CommittedConsistency
+  AbortedConsistency
+  RollbackConsistency
+  UniqueWrite
+  SnapshotIsolation

--- a/CollapseRollbacks/Test2.tla
+++ b/CollapseRollbacks/Test2.tla
@@ -1,0 +1,14 @@
+--------------------------------- MODULE Test2 ---------------------------------
+
+EXTENDS CollapseRollbacks, TLC
+
+\* We use one table with 2 keys and 2 concurrent clients for TLC model checking.
+\* These 2 clients have primary key 1 and 2 respectively.
+
+CONSTANTS c1, c2
+
+Key == {1, 2}
+Client == {c1, c2}
+ClientPrimaryKey == c1 :> 1 @@ c2 :> 2
+
+================================================================================


### PR DESCRIPTION
this pr is to move `collapserollback` optimization to a separate directory. 
`collapserollback` optimization was done in this  https://github.com/pingcap/tla-plus/pull/23  

@siddontang @GregoryIan PTAL